### PR TITLE
TBD-71 포탑 공격 상태 일부 수정

### DIFF
--- a/Assets/Scripts/Turret/Projectile.cs
+++ b/Assets/Scripts/Turret/Projectile.cs
@@ -39,8 +39,6 @@ public class Projectile : MonoBehaviour
 
         if (Vector3.Distance(gameObject.transform.position, target.position) < 0.8f)
         {
-            // 공격
-            Debug.Log("Attack!!!!");
             target.gameObject.GetComponent<Entity>().GetHit(damage);
             gameObject.SetActive(false);
         }

--- a/Assets/Scripts/Turret/TurretAttackState.cs
+++ b/Assets/Scripts/Turret/TurretAttackState.cs
@@ -8,16 +8,16 @@ public class TurretAttackState : StateMachineBehaviour
     override public void OnStateEnter(Animator animator, AnimatorStateInfo stateInfo, int layerIndex)
     {
         turretBehavior = animator.GetComponent<TurretBehavior>();
+        turretBehavior.isAttack = true;
         turretBehavior.Attacking();
     }
 
     override public void OnStateUpdate(Animator animator, AnimatorStateInfo stateInfo, int layerIndex)
     {
-        turretBehavior.AttackCondition();
     }
 
     override public void OnStateExit(Animator animator, AnimatorStateInfo stateInfo, int layerIndex)
     {
-        turretBehavior.StopAttacking();
+        turretBehavior.isAttack = false;
     }
 }

--- a/Assets/Scripts/Turret/TurretBehavior.cs
+++ b/Assets/Scripts/Turret/TurretBehavior.cs
@@ -73,7 +73,7 @@ public class TurretBehavior : MonoBehaviour
 
     IEnumerator AttackCo()
     {
-        while(true)
+        while(AttackCondition())
         {
             projectileClone.SetActive(true);
             yield return new WaitForSeconds(2f);
@@ -83,11 +83,6 @@ public class TurretBehavior : MonoBehaviour
     public void Attacking()
     {
         StartCoroutine(AttackCo());
-    }
-
-    public void StopAttacking()
-    {
-        StopCoroutine(AttackCo());
     }
 
     public bool AttackCondition()
@@ -103,6 +98,11 @@ public class TurretBehavior : MonoBehaviour
             return false;
         }
         else if (Vector3.Distance(target.position, transform.position) > detectionRange)
+        {
+            anim.SetBool(hashAttackStart, false);
+            return false;
+        }
+        else if (!isAttack)
         {
             anim.SetBool(hashAttackStart, false);
             return false;

--- a/Assets/Scripts/Turret/TurretDetectionState.cs
+++ b/Assets/Scripts/Turret/TurretDetectionState.cs
@@ -17,6 +17,5 @@ public class TurretDetectionState : StateMachineBehaviour
 
     override public void OnStateExit(Animator animator, AnimatorStateInfo stateInfo, int layerIndex)
     {
-        turretBehavior.isAttack = true;
     }
 }


### PR DESCRIPTION
## 설명

1. TurretBehavior 클래스에 있던 투사체를 활성화하는 코루틴을 끄는 코드를 삭제하고, AttackCondition() 조건을 통하여 코루틴이 꺼지도록 하였습니다.

2. 공격 상태에서 사망 상태로 넘어갈 때 코루틴이 꺼지지 않는 문제를 수정하였습니다.