### PR TITLE
TBD-73 스킬 취소 추가

### DIFF
--- a/Assets/Prefabs/Skill.prefab
+++ b/Assets/Prefabs/Skill.prefab
@@ -95,9 +95,9 @@ MonoBehaviour:
   radius: 15
   activeColor: {r: 1, g: 1, b: 1, a: 1}
   iconSprite: {fileID: 21300000, guid: 2d0997ac1b1fd664e98202450e7ea2d7, type: 3}
-  objectToSpawn: {fileID: 613292779795284151, guid: ebd7292e888c84f05924605e51048072,
+  objectToSpawn: {fileID: 7409688834058636024, guid: 26b7b3213bcfddb4397d152d6a28e3f8,
     type: 3}
-  offset: {x: 0, y: 0, z: 0}
+  offset: {x: 0, y: 9, z: 0}
   groundLayer:
     serializedVersion: 2
     m_Bits: 256

--- a/Assets/Scripts/Skill.cs
+++ b/Assets/Scripts/Skill.cs
@@ -1,3 +1,5 @@
+using System;
+using DTT.AreaOfEffectRegions;
 using UnityEngine;
 using UnityEngine.EventSystems;
 using UnityEngine.UI;
@@ -26,6 +28,7 @@ public class Skill : MonoBehaviour, IBeginDragHandler, IDragHandler, IEndDragHan
     private GameObject _draggingObject;
     public Vector3 offset;
     public LayerMask groundLayer = 1 << 8; // Ground 레이어
+    private SRPCircleRegionProjector _circleRegion;
 
     private void Start()
     {
@@ -37,6 +40,9 @@ public class Skill : MonoBehaviour, IBeginDragHandler, IDragHandler, IEndDragHan
 
         _draggingObject = Instantiate(objectToSpawn);
         _draggingObject.SetActive(false);
+
+        _circleRegion = _draggingObject.GetComponent<SRPCircleRegionProjector>();
+        _circleRegion.Radius = radius;
     }
 
     /// <summary>
@@ -75,12 +81,12 @@ public class Skill : MonoBehaviour, IBeginDragHandler, IDragHandler, IEndDragHan
 
         if (isHit)
         {
-            _draggingObject.transform.position = hit.point + offset;
-            _draggingObject.transform.rotation = hit.transform.rotation; 
+            _draggingObject.SetActive(true);
+            _draggingObject.transform.SetPositionAndRotation(hit.point + offset, hit.transform.rotation);
         }
 
-        // TBD-73에서 수정 예정
-        _draggingObject.SetActive(isHit);
+        _circleRegion.FillProgress = Convert.ToInt32(isHit);
+        _circleRegion.GenerateProjector();
     }
 
     public void OnEndDrag(PointerEventData eventData)
@@ -89,6 +95,15 @@ public class Skill : MonoBehaviour, IBeginDragHandler, IDragHandler, IEndDragHan
 
         if (_draggingObject != null)
             _draggingObject.SetActive(false);
+
+        if (_circleRegion.FillProgress == 0)
+        {
+            Debug.Log("스킬 취소");
+        }
+        else
+        {
+            Debug.Log("스킬 발동");
+        }
 
         _isAiming = false;
     }

--- a/Assets/Settings/URP-Performant-Renderer.asset
+++ b/Assets/Settings/URP-Performant-Renderer.asset
@@ -1,5 +1,28 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
+--- !u!114 &-4535664067646470068
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a1614fc811f8f184697d9bee70ab9fe5, type: 3}
+  m_Name: DecalRendererFeature
+  m_EditorClassIdentifier: 
+  m_Active: 1
+  m_Settings:
+    technique: 0
+    maxDrawDistance: 1000
+    decalLayers: 0
+    dBufferSettings:
+      surfaceData: 2
+    screenSpaceSettings:
+      normalBlend: 0
+  m_CopyDepthPS: {fileID: 4800000, guid: d6dae50ee9e1bfa4db75f19f99355220, type: 3}
+  m_DBufferClear: {fileID: 4800000, guid: f056d8bd2a1c7e44e9729144b4c70395, type: 3}
 --- !u!114 &11400000
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -18,7 +41,8 @@ MonoBehaviour:
     hdrDebugViewPS: {fileID: 4800000, guid: 573620ae32aec764abd4d728906d2587, type: 3}
   m_RendererFeatures:
   - {fileID: 3239328064754543239}
-  m_RendererFeatureMap: 87eaa552b667f42c
+  - {fileID: -4535664067646470068}
+  m_RendererFeatureMap: 87eaa552b667f42c4cc86dbb8f150ec1
   m_UseNativeRenderPass: 0
   postProcessData: {fileID: 11400000, guid: 41439944d30ece34e96484bdb6645b55, type: 2}
   xrSystemData: {fileID: 11400000, guid: 60e1133243b97e347b653163a8c01b64, type: 2}

--- a/ProjectSettings/ProjectSettings.asset
+++ b/ProjectSettings/ProjectSettings.asset
@@ -803,6 +803,7 @@ PlayerSettings:
   webGLMemoryGeometricGrowthCap: 96
   webGLPowerPreference: 2
   scriptingDefineSymbols:
+    Android: UNIVERSAL_PACKAGE
     Standalone: UNIVERSAL_PACKAGE;PUBLISHING_TOOLS_ASSET_STORE_RELEASE;AREA_OF_EFFECT_REGIONS_ASSET_STORE_RELEASE
     iPhone: UNITY_XR_ARKIT_LOADER_ENABLED
   additionalCompilerArguments: {}


### PR DESCRIPTION
# 스킬 사용 여부

## 요약

![DefenseARGame - Untitled - Android - Unity 2022 3 19f1_ _DX11_ 2024-07-24 16-03-04](https://github.com/user-attachments/assets/6a0a69ea-463f-4d1a-8431-60d1278084fe)

[해당 에셋](https://assetstore.unity.com/packages/vfx/skill-attack-indicators-221125)을 사용하여 스킬을 조준했을 때 스킬을 사용할 수 있는지 가시적으로 나타냈습니다.

## 내용

![image](https://github.com/user-attachments/assets/d7320f0a-12b1-4f1d-bc9a-f043cd9c9216)

스킬의 영향 범위를 나타내는 에셋을 스킬 프리팹에 추가했습니다.

위의 내용은 `Skill.cs`에서 관리합니다.

```cs
private void SetDraggedPosition(PointerEventData data)
{
    bool isHit = Physics.Raycast(Camera.main.ScreenPointToRay(data.position), out RaycastHit hit, 100f, groundLayer);

    if (isHit)
    {
        _draggingObject.SetActive(true);
        _draggingObject.transform.SetPositionAndRotation(hit.point + offset, hit.transform.rotation);
    }

    _circleRegion.FillProgress = Convert.ToInt32(isHit);
    _circleRegion.GenerateProjector();
}
```

`_circleRegion.GenerateProjector()`를 `Start()`에서 한 번만 실행하면 `_circleRegion.FillProgress` 값을 바꿔도 적용이 되지 않는 문제가 있었습니다.

이 문제는 드래그할 때마다 함수를 실행하는 것으로 해결하였으나 비용 문제가 발생할 것으로 예상됩니다.