### PR TITLE
TBD-78 스킬에 누락된 기능 추가

### DIFF
--- a/Assets/Resources/Prefabs/Skill.prefab
+++ b/Assets/Resources/Prefabs/Skill.prefab
@@ -99,13 +99,13 @@ MonoBehaviour:
     m_Bits: 256
   skillName: "\uBA54\uD14C\uC624"
   requireMana: 4
-  damage: 50
-  radius: 9
-  duration: 4
+  damage: 10
+  radius: 0.09
   effectToSpawn: {fileID: 7957833072274404953, guid: 3355f6bfa6db8b24281b827de929694c,
     type: 3}
+  duration: 3
   attackDelay: 1
-  attackRepeatRate: 1
+  attackRepeatRate: 0.5
 --- !u!1 &7468208254341150408
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/Manager/GameManager.cs
+++ b/Assets/Scripts/Manager/GameManager.cs
@@ -20,7 +20,7 @@ public class GameManager : MonoBehaviour
     #region 스킬
 
     public const int MaxMana = 10;
-    public int CurrentMana { get; private set; }
+    public int CurrentMana { get; private set; } = 10;
 
     private readonly float _manaRegenInterval = 2.0f;
     private float _manaTimer;

--- a/Assets/Scripts/Skill/RapidFireSkill.cs
+++ b/Assets/Scripts/Skill/RapidFireSkill.cs
@@ -5,8 +5,9 @@ public class RapidFireSkill : Skill
 {
     [Header("스킬 상세")]
     public GameObject effectToSpawn;
+    [Range(1f, 5f)] public float duration = 3f;
     [Range(0.1f, 5f), Tooltip("첫 공격까지의 대기 시간")] public float attackDelay = 1f;
-    [Range(0.1f, 5f), Tooltip("다음 공격까지의 대기 시간")] public float attackRepeatRate = 1f;
+    [Range(0.1f, 5f), Tooltip("다음 공격까지의 대기 시간")] public float attackRepeatRate = 0.5f;
 
     protected override void Activate()
     {
@@ -17,6 +18,8 @@ public class RapidFireSkill : Skill
                 draggingObject.transform.rotation
             ).GetComponent<ParticleSystem>();
 
+        effect.transform.localScale = Vector3.one * (Circle.Radius / 9);
+
         Destroy(effect.gameObject, effect.main.duration);
 
         StartCoroutine(RepeatShooting(effect.transform.position, attackDelay, attackRepeatRate));
@@ -26,22 +29,18 @@ public class RapidFireSkill : Skill
     {
         yield return new WaitForSeconds(time);
 
-        float tick = time;
-
-        do
+        for (float i = 0; i <= duration - time; i += repeatRate)
         {
-            tick += repeatRate;
-
             Collider[] targets = new Collider[10];
-            int count = Physics.OverlapSphereNonAlloc(position, radius / 2, targets, 1 << 6);
+            int targetAmount = Physics.OverlapSphereNonAlloc(position, radius / 2, targets, 1 << 6);
 
-            for (int i = 0; i < count; i++)
+            for (int j = 0; j < targetAmount; j++)
             {
-                if (!targets[i].CompareTag("Minion")) continue;
-                targets[i].GetComponent<MinionBehaviour>().GetHit((int)(damage / duration));
+                if (!targets[j].CompareTag("Minion")) continue;
+                targets[j].GetComponent<MinionBehaviour>().GetHit(damage);
             }
 
             yield return new WaitForSeconds(repeatRate);
-        } while (tick < duration);
+        }
     }
 }


### PR DESCRIPTION
## 기능

![DefenseARGame - ObjectPool - Android - Unity 2022 3 19f1_ _DX11_ 2024-07-26 16-22-48](https://github.com/user-attachments/assets/e922b9ac-e563-4593-a131-55996bed6bc3)

아이콘 쪽으로 드래그할 때도 스킬이 취소되는 기능을 추가했습니다.

## 내용

![image](https://github.com/user-attachments/assets/a302610b-83df-4f67-8952-f05b40f9028e)

- 이펙트에 맞춰 스킬의 대미지 로직을 변경했습니다.
- 드래그를 아이콘 쪽으로 했을 때에도 스킬 취소가 되어야 했지만 누락되었습니다. 이를 추가했습니다.

## 발견한 문제

AR에서의 플레이를 가정하고 맵 사이즈를 줄여서 테스트를 진행했을 때, 문제가 발생했습니다.

![DefenseARGame - ObjectPool - Android - Unity 2022 3 19f1_ _DX11_ 2024-07-26 16-33-15](https://github.com/user-attachments/assets/3c4b0314-f9d9-45fe-913d-b524086e7970)

맵의 크기에 따라 미니언의 크기도 변경되어야 할 것 같습니다.

## 추가해야 할 이슈

- 맵 사이즈에 따라 스킬 범위 변경
- 미리 추가된 UI에 스킬 컴포넌트가 추가되는 형태로 코드를 변경
- 맵 사이즈에 따라 스폰되는 미니언, 투사체의 크기 변경