### PR TITLE
TBD-94 전투 종료 후 초기화

### DIFF
--- a/Assets/Scripts/Manager/GameManagerEx.cs
+++ b/Assets/Scripts/Manager/GameManagerEx.cs
@@ -7,6 +7,7 @@ using UnityEngine.XR.Interaction.Toolkit.Samples.StarterAssets;
 public class GameManagerEx
 {
     private ObjectSpawner _objectSpawner;
+    private GameObject _map;
 
     public void Init()
     {
@@ -23,19 +24,37 @@ public class GameManagerEx
         }
     }
 
+    public bool ReadyGame()
+    {
+        if (!_objectSpawner) return false;
+
+        _objectSpawner.gameObject.SetActive(true);
+
+        Managers.Resource.Load<Material>("Materials/M_Plane").color = new Color(1f, 1f, 0f, 0.05f);
+
+        return true;
+    }
+
     public bool StartGame()
     {
         if (_objectSpawner.transform.childCount == 0) return false;
 
         Transform mapPreview = _objectSpawner.transform.GetChild(0);
 
-        GameObject map = Managers.Resource.Instantiate("MAP/ProtoMap");
-        map.transform.SetPositionAndRotation(mapPreview.position, mapPreview.rotation);
-        map.transform.localScale = mapPreview.localScale;
+        _map = Managers.Resource.Instantiate("MAP/ProtoMap");
+        _map.transform.SetPositionAndRotation(mapPreview.position, mapPreview.rotation);
+        _map.transform.localScale = mapPreview.localScale;
 
         Object.Destroy(mapPreview.gameObject);
         _objectSpawner.gameObject.SetActive(false);
 
+        return true;
+    }
+
+    public bool FinishGame()
+    {
+        if (!_map) return false;
+        Object.Destroy(_map);
         return true;
     }
 }

--- a/Assets/Scripts/Manager/MinionSpawnManager.cs
+++ b/Assets/Scripts/Manager/MinionSpawnManager.cs
@@ -48,7 +48,7 @@ public class MinionSpawnManager : MonoBehaviour
 
     private MinionBehaviour CreateMinion()
     {
-        MinionBehaviour minionInstance = Instantiate(minionPrefab);
+        MinionBehaviour minionInstance = Instantiate(minionPrefab, transform.parent);
         minionInstance.ObjectPool = objectPool;
         minionInstance.name = count.ToString();
         count++;

--- a/Assets/Scripts/UI/Popup/UI_LevelPopup.cs
+++ b/Assets/Scripts/UI/Popup/UI_LevelPopup.cs
@@ -65,7 +65,7 @@ public class UI_LevelPopup : UI_Popup
         Managers.UI.ClosePopupUI(this);
         Managers.UI.ShowPopupUI<UI_MapSettingPopup>();
 
-        Managers.Resource.Load<Material>("Materials/M_Plane").color = new Color(1f, 1f, 0f, 0.05f);
+        Managers.Game.ReadyGame();
     }
 
     void OnClickMiddleButton()
@@ -75,8 +75,7 @@ public class UI_LevelPopup : UI_Popup
         Managers.UI.ClosePopupUI(this);
         Managers.UI.ShowPopupUI<UI_MapSettingPopup>();
 
-        Managers.Resource.Load<Material>("Materials/M_Plane").color = new Color(1f, 1f, 0f, 0.05f);
-
+        Managers.Game.ReadyGame();
     }
 
     void OnClickLowButton()
@@ -85,7 +84,7 @@ public class UI_LevelPopup : UI_Popup
         Managers.UI.ClosePopupUI(this);
         Managers.UI.ShowPopupUI<UI_MapSettingPopup>();
 
-        Managers.Resource.Load<Material>("Materials/M_Plane").color = new Color(1f, 1f, 0f, 0.05f);
+        Managers.Game.ReadyGame();
     }
 
     void GoUp() => selectSection.position = Vector3.MoveTowards(selectSection.position, upPos, MovingSpeed);

--- a/Assets/Scripts/UI/Popup/UI_ResultDefeatPopup.cs
+++ b/Assets/Scripts/UI/Popup/UI_ResultDefeatPopup.cs
@@ -27,6 +27,8 @@ public class UI_ResultDefeatPopup : UI_Popup
         Managers.UI.ClosePopupUI(this);
 
         Managers.UI.ShowPopupUI<UI_LevelPopup>();
+
+        Managers.Game.FinishGame();
     }
 
 }

--- a/Assets/Scripts/UI/Popup/UI_ResultVictoryPopup.cs
+++ b/Assets/Scripts/UI/Popup/UI_ResultVictoryPopup.cs
@@ -31,6 +31,8 @@ public class UI_ResultVictoryPopup : UI_Popup
         Managers.UI.ClosePopupUI(this);
 
         Managers.UI.ShowPopupUI<UI_LevelPopup>();
+
+        Managers.Game.FinishGame();
     }
 
 }


### PR DESCRIPTION
## 내용

전투 종료 후 맵이 그대로 남아있는 문제를 수정했습니다.

## 추가

맵을 제거했을 때 미니언은 그대로 남아있는 문제가 있었습니다.\
따라서 미니언의 생성을 스폰 매니저의 자식으로 생성되도록 변경하여 맵이 파괴될 때 미니언도 같이 제거되도록 했습니다.

문제는 해결된 것으로 보이나 테스트를 진행하는 중 유니티에서 오류로 인한 강제 종료가 발생하여 확실한 테스트가 불가능합니다.

아래와 같은 에러가 발생할 경우 `MinionBehaviour minionInstance = Instantiate(minionPrefab, transform.parent);`에서 `transform.parent`가 아닌 `transform`으로 수정하여 확인부탁드립니다.

![image](https://github.com/user-attachments/assets/c41d22b8-ee8e-4793-99cc-75d7f88e298f)