### PR TITLE
포탑 버그 수정

### DIFF
--- a/Assets/Resources/Materials/M_Plane.mat
+++ b/Assets/Resources/Materials/M_Plane.mat
@@ -131,8 +131,8 @@ Material:
     - _WorkflowMode: 1
     - _ZWrite: 0
     m_Colors:
-    - _BaseColor: {r: 1, g: 1, b: 0, a: 0.01}
-    - _Color: {r: 1, g: 1, b: 0, a: 0.01}
+    - _BaseColor: {r: 0, g: 0, b: 0, a: 0}
+    - _Color: {r: 1, g: 1, b: 0, a: 0.05}
     - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}
     - _SpecColor: {r: 0.19999996, g: 0.19999996, b: 0.19999996, a: 1}
   m_BuildTextureStacks: []

--- a/Assets/Resources/Prefabs/MAP/ProtoMap.prefab
+++ b/Assets/Resources/Prefabs/MAP/ProtoMap.prefab
@@ -324,6 +324,21 @@ PrefabInstance:
       propertyPath: m_StaticEditorFlags
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 2312172258358982076, guid: 4bee4ad5f46db8f49956032434fbb167,
+        type: 3}
+      propertyPath: damage
+      value: 30
+      objectReference: {fileID: 0}
+    - target: {fileID: 2312172258358982076, guid: 4bee4ad5f46db8f49956032434fbb167,
+        type: 3}
+      propertyPath: moveSpeed
+      value: 21
+      objectReference: {fileID: 0}
+    - target: {fileID: 2312172258358982076, guid: 4bee4ad5f46db8f49956032434fbb167,
+        type: 3}
+      propertyPath: projectileSpeed
+      value: 21
+      objectReference: {fileID: 0}
     - target: {fileID: 3801772920916890706, guid: 4bee4ad5f46db8f49956032434fbb167,
         type: 3}
       propertyPath: m_LocalPosition.x
@@ -379,6 +394,11 @@ PrefabInstance:
       propertyPath: m_StaticEditorFlags
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 5083129782104804837, guid: 4bee4ad5f46db8f49956032434fbb167,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 16
+      objectReference: {fileID: 0}
     - target: {fileID: 5799819158640104307, guid: 4bee4ad5f46db8f49956032434fbb167,
         type: 3}
       propertyPath: m_Name
@@ -388,6 +408,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_StaticEditorFlags
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6717904292888544850, guid: 4bee4ad5f46db8f49956032434fbb167,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 16
       objectReference: {fileID: 0}
     - target: {fileID: 7136895306085171928, guid: 4bee4ad5f46db8f49956032434fbb167,
         type: 3}
@@ -408,6 +433,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_StaticEditorFlags
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9095678631417882951, guid: 4bee4ad5f46db8f49956032434fbb167,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 18
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
@@ -430,9 +460,44 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 134525324158293428, guid: 0564b90cd24e5984b99fcb0952b00ae5,
         type: 3}
+      propertyPath: hp
+      value: 1000
+      objectReference: {fileID: 0}
+    - target: {fileID: 134525324158293428, guid: 0564b90cd24e5984b99fcb0952b00ae5,
+        type: 3}
+      propertyPath: maxHP
+      value: 1000
+      objectReference: {fileID: 0}
+    - target: {fileID: 134525324158293428, guid: 0564b90cd24e5984b99fcb0952b00ae5,
+        type: 3}
+      propertyPath: damage
+      value: 30
+      objectReference: {fileID: 0}
+    - target: {fileID: 134525324158293428, guid: 0564b90cd24e5984b99fcb0952b00ae5,
+        type: 3}
       propertyPath: subject
       value: 
       objectReference: {fileID: 4142996030918743271}
+    - target: {fileID: 134525324158293428, guid: 0564b90cd24e5984b99fcb0952b00ae5,
+        type: 3}
+      propertyPath: moveSpeed
+      value: 21
+      objectReference: {fileID: 0}
+    - target: {fileID: 134525324158293428, guid: 0564b90cd24e5984b99fcb0952b00ae5,
+        type: 3}
+      propertyPath: projectileSpeed
+      value: 21
+      objectReference: {fileID: 0}
+    - target: {fileID: 273047647059546595, guid: 0564b90cd24e5984b99fcb0952b00ae5,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 12
+      objectReference: {fileID: 0}
+    - target: {fileID: 841282641426167004, guid: 0564b90cd24e5984b99fcb0952b00ae5,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 12
+      objectReference: {fileID: 0}
     - target: {fileID: 1050527532033867651, guid: 0564b90cd24e5984b99fcb0952b00ae5,
         type: 3}
       propertyPath: m_LocalPosition.x
@@ -528,6 +593,11 @@ PrefabInstance:
       propertyPath: enemyMainTurret
       value: 
       objectReference: {fileID: 8706143598941973846}
+    - target: {fileID: 3904442095633844747, guid: 0564b90cd24e5984b99fcb0952b00ae5,
+        type: 3}
+      propertyPath: m_UseGravity
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 3946722403503497732, guid: 0564b90cd24e5984b99fcb0952b00ae5,
         type: 3}
       propertyPath: m_StaticEditorFlags
@@ -613,10 +683,25 @@ PrefabInstance:
       propertyPath: m_CarveOnlyStationary
       value: 1
       objectReference: {fileID: 0}
+    - target: {fileID: 6814826450719315837, guid: 0564b90cd24e5984b99fcb0952b00ae5,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 14
+      objectReference: {fileID: 0}
     - target: {fileID: 7161237787725484302, guid: 0564b90cd24e5984b99fcb0952b00ae5,
         type: 3}
       propertyPath: m_Name
       value: MainTurret_Red
+      objectReference: {fileID: 0}
+    - target: {fileID: 7985605789303817609, guid: 0564b90cd24e5984b99fcb0952b00ae5,
+        type: 3}
+      propertyPath: m_Extents.x
+      value: 6.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 7985605789303817609, guid: 0564b90cd24e5984b99fcb0952b00ae5,
+        type: 3}
+      propertyPath: m_Extents.z
+      value: 6.5
       objectReference: {fileID: 0}
     - target: {fileID: 8859492150840193415, guid: 0564b90cd24e5984b99fcb0952b00ae5,
         type: 3}
@@ -748,6 +833,36 @@ PrefabInstance:
       propertyPath: m_StaticEditorFlags
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 5726857791050026359, guid: c3407b84771099a4b9b2c973a8e7b681,
+        type: 3}
+      propertyPath: damage
+      value: 30
+      objectReference: {fileID: 0}
+    - target: {fileID: 5726857791050026359, guid: c3407b84771099a4b9b2c973a8e7b681,
+        type: 3}
+      propertyPath: moveSpeed
+      value: 21
+      objectReference: {fileID: 0}
+    - target: {fileID: 5726857791050026359, guid: c3407b84771099a4b9b2c973a8e7b681,
+        type: 3}
+      propertyPath: projectileSpeed
+      value: 21
+      objectReference: {fileID: 0}
+    - target: {fileID: 6909217342074985759, guid: c3407b84771099a4b9b2c973a8e7b681,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 18
+      objectReference: {fileID: 0}
+    - target: {fileID: 6933433693433492583, guid: c3407b84771099a4b9b2c973a8e7b681,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 16
+      objectReference: {fileID: 0}
+    - target: {fileID: 7033370537332435148, guid: c3407b84771099a4b9b2c973a8e7b681,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 16
+      objectReference: {fileID: 0}
     - target: {fileID: 7508949857222408736, guid: c3407b84771099a4b9b2c973a8e7b681,
         type: 3}
       propertyPath: m_Name
@@ -791,6 +906,21 @@ PrefabInstance:
         type: 3}
       propertyPath: m_StaticEditorFlags
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2312172258358982076, guid: 4bee4ad5f46db8f49956032434fbb167,
+        type: 3}
+      propertyPath: damage
+      value: 30
+      objectReference: {fileID: 0}
+    - target: {fileID: 2312172258358982076, guid: 4bee4ad5f46db8f49956032434fbb167,
+        type: 3}
+      propertyPath: moveSpeed
+      value: 21
+      objectReference: {fileID: 0}
+    - target: {fileID: 2312172258358982076, guid: 4bee4ad5f46db8f49956032434fbb167,
+        type: 3}
+      propertyPath: projectileSpeed
+      value: 21
       objectReference: {fileID: 0}
     - target: {fileID: 3801772920916890706, guid: 4bee4ad5f46db8f49956032434fbb167,
         type: 3}
@@ -847,6 +977,11 @@ PrefabInstance:
       propertyPath: m_StaticEditorFlags
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 5083129782104804837, guid: 4bee4ad5f46db8f49956032434fbb167,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 16
+      objectReference: {fileID: 0}
     - target: {fileID: 5799819158640104307, guid: 4bee4ad5f46db8f49956032434fbb167,
         type: 3}
       propertyPath: m_Name
@@ -856,6 +991,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_StaticEditorFlags
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6717904292888544850, guid: 4bee4ad5f46db8f49956032434fbb167,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 16
       objectReference: {fileID: 0}
     - target: {fileID: 7136895306085171928, guid: 4bee4ad5f46db8f49956032434fbb167,
         type: 3}
@@ -876,6 +1016,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_StaticEditorFlags
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 9095678631417882951, guid: 4bee4ad5f46db8f49956032434fbb167,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 18
       objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
@@ -946,6 +1091,16 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 562329404902882484, guid: 5395a7560fd578a47868c4ce0dc16f80,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 12
+      objectReference: {fileID: 0}
+    - target: {fileID: 784341130252450446, guid: 5395a7560fd578a47868c4ce0dc16f80,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 14
+      objectReference: {fileID: 0}
     - target: {fileID: 1361239670300140045, guid: 5395a7560fd578a47868c4ce0dc16f80,
         type: 3}
       propertyPath: m_StaticEditorFlags
@@ -986,16 +1141,51 @@ PrefabInstance:
       propertyPath: m_StaticEditorFlags
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 4201366839915233891, guid: 5395a7560fd578a47868c4ce0dc16f80,
+        type: 3}
+      propertyPath: m_UseGravity
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 4843015503663077734, guid: 5395a7560fd578a47868c4ce0dc16f80,
         type: 3}
       propertyPath: m_StaticEditorFlags
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5620954009364840426, guid: 5395a7560fd578a47868c4ce0dc16f80,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 12
+      objectReference: {fileID: 0}
+    - target: {fileID: 5788211565893414597, guid: 5395a7560fd578a47868c4ce0dc16f80,
+        type: 3}
+      propertyPath: hp
+      value: 1000
+      objectReference: {fileID: 0}
+    - target: {fileID: 5788211565893414597, guid: 5395a7560fd578a47868c4ce0dc16f80,
+        type: 3}
+      propertyPath: maxHP
+      value: 1000
+      objectReference: {fileID: 0}
+    - target: {fileID: 5788211565893414597, guid: 5395a7560fd578a47868c4ce0dc16f80,
+        type: 3}
+      propertyPath: damage
+      value: 30
       objectReference: {fileID: 0}
     - target: {fileID: 5788211565893414597, guid: 5395a7560fd578a47868c4ce0dc16f80,
         type: 3}
       propertyPath: subject
       value: 
       objectReference: {fileID: 4142996030918743271}
+    - target: {fileID: 5788211565893414597, guid: 5395a7560fd578a47868c4ce0dc16f80,
+        type: 3}
+      propertyPath: moveSpeed
+      value: 21
+      objectReference: {fileID: 0}
+    - target: {fileID: 5788211565893414597, guid: 5395a7560fd578a47868c4ce0dc16f80,
+        type: 3}
+      propertyPath: projectileSpeed
+      value: 21
+      objectReference: {fileID: 0}
     - target: {fileID: 7172609978900884115, guid: 5395a7560fd578a47868c4ce0dc16f80,
         type: 3}
       propertyPath: m_TagString
@@ -1145,6 +1335,36 @@ PrefabInstance:
         type: 3}
       propertyPath: m_StaticEditorFlags
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5726857791050026359, guid: c3407b84771099a4b9b2c973a8e7b681,
+        type: 3}
+      propertyPath: damage
+      value: 30
+      objectReference: {fileID: 0}
+    - target: {fileID: 5726857791050026359, guid: c3407b84771099a4b9b2c973a8e7b681,
+        type: 3}
+      propertyPath: moveSpeed
+      value: 21
+      objectReference: {fileID: 0}
+    - target: {fileID: 5726857791050026359, guid: c3407b84771099a4b9b2c973a8e7b681,
+        type: 3}
+      propertyPath: projectileSpeed
+      value: 21
+      objectReference: {fileID: 0}
+    - target: {fileID: 6909217342074985759, guid: c3407b84771099a4b9b2c973a8e7b681,
+        type: 3}
+      propertyPath: m_AnchoredPosition.y
+      value: 18
+      objectReference: {fileID: 0}
+    - target: {fileID: 6933433693433492583, guid: c3407b84771099a4b9b2c973a8e7b681,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 16
+      objectReference: {fileID: 0}
+    - target: {fileID: 7033370537332435148, guid: c3407b84771099a4b9b2c973a8e7b681,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 16
       objectReference: {fileID: 0}
     - target: {fileID: 7508949857222408736, guid: c3407b84771099a4b9b2c973a8e7b681,
         type: 3}

--- a/Assets/Resources/Prefabs/Turret/RevisedProjectile.prefab
+++ b/Assets/Resources/Prefabs/Turret/RevisedProjectile.prefab
@@ -106,7 +106,7 @@ Rigidbody:
     m_Bits: 0
   m_ImplicitCom: 1
   m_ImplicitTensor: 1
-  m_UseGravity: 1
+  m_UseGravity: 0
   m_IsKinematic: 0
   m_Interpolate: 0
   m_Constraints: 0

--- a/Assets/Scripts/Minion/MinionWeapon.cs
+++ b/Assets/Scripts/Minion/MinionWeapon.cs
@@ -18,7 +18,7 @@ public class MinionWeapon : MonoBehaviour
         {
             enemyLayer = 6;
         }
-        damage = 10;
+        damage = 20;
     }
 
     private void OnTriggerEnter(Collider other)

--- a/Assets/Scripts/Turret/TurretBehaviour.cs
+++ b/Assets/Scripts/Turret/TurretBehaviour.cs
@@ -14,6 +14,7 @@ public class TurretBehaviour : Entity
     [SerializeField] private Canvas hpBar;
     [SerializeField] private Transform spawnPoint;
     [SerializeField] private Subject subject;
+    [SerializeField] private float projectileSpeed;
     public Transform target { get; private set; }
     private Animator animator;
     private Collider turretCollier;
@@ -21,9 +22,8 @@ public class TurretBehaviour : Entity
 
     public bool isDead { get; private set; }
     private float detectionRange = 10f;
-    public float moveSpeed = 7.0f;
     private bool isAttack = false;
-
+    private IEnumerator attackCoroutine;
 
 
     private void Awake()
@@ -36,8 +36,6 @@ public class TurretBehaviour : Entity
         projectile.transform.position = spawnPoint.transform.position;
         projectile.SetActive(false);
         enemyLayerSet();
-        
-
 
     }
 
@@ -46,8 +44,8 @@ public class TurretBehaviour : Entity
     {
         if (isAttack)
         {
-            Vector3 moveDir = target.transform.position - projectile.transform.position;
-            projectileRigid.MovePosition(projectile.transform.position + moveDir * moveSpeed * Time.fixedDeltaTime);
+            Vector3 moveDir = (target.transform.position - projectile.transform.position).normalized;
+            projectileRigid.MovePosition(projectile.transform.position + moveDir * projectileSpeed * Time.fixedDeltaTime);
          
             if (Vector3.Distance(projectile.transform.position, target.position) < 0.8f)
             {
@@ -91,7 +89,11 @@ public class TurretBehaviour : Entity
         }
 
         enemyMinions = enemyMinions.OrderBy(enemyMinion => Vector3.Distance(enemyMinion.position, thisTransform.position)).ToList<Transform>();
-        target = enemyMinions[0];
+
+        if (enemyMinions.Count > 0)
+        {
+            target = enemyMinions[0];
+        }
         enemyMinions.Clear();
 
         return target;
@@ -99,20 +101,21 @@ public class TurretBehaviour : Entity
 
     public void StartAttack()
     {
-        StartCoroutine(Attack());
+        attackCoroutine = Attack();
+        StartCoroutine(attackCoroutine);
     }
 
     public void StopAttack()
     {
-        StopCoroutine(Attack());
+        StopCoroutine(attackCoroutine);
     }
 
     IEnumerator Attack()
     {
         while (true)
         {
-            projectile.transform.position = spawnPoint.transform.position;
             projectile.SetActive(true);
+            projectile.transform.position = spawnPoint.transform.position;
             yield return new WaitForSeconds(2f);
         }
     }


### PR DESCRIPTION
## 설명
1. 포탑 투사체 버그

 - 버그 내용 : 투사체가 2초 간격으로 공격하지 않고 점점 빨리 공격하는 버그 발생

 - 버그 원인: 코루틴을 올바르게 정지시키지 못함

    [기존 코드]
    
    ```cs
    public void StartAttack()
        {
            StartCoroutine(Attack());
        }
    
        public void StopAttack()
        {
            StopCoroutine(Attack());
        }
    ```
    [수정된 코드]
    
    ```cs
        public void StartAttack()
        {
            attackCoroutine = Attack();
            StartCoroutine(attackCoroutine);
        }
    
        public void StopAttack()
        {
            StopCoroutine(attackCoroutine);
        }
    ```

2. 메인 포탑 투사체 버그

 - 버그 내용 : 메인포탑의 투사체가 미니언을향하지 않고 아래로 떨어지는 버그

 - 버그 원인: 투사체의 Rigidbody컴포넌트에 Use Gravity가 활성화 되어있었음

    [기존 투사체]
    ![image-20240728-074817](https://github.com/user-attachments/assets/7bc7d54b-1a56-4a75-8926-94b4c09b5f08)
    
    
    [수정된 투사체]
    ![image-20240728-074857](https://github.com/user-attachments/assets/5d957188-d3bc-40eb-862c-bbe5b2dc63ac)

