### PR TITLE
미니언 버그 수정

### DIFF
--- a/Assets/Scripts/Minion/MinionBehaviour.cs
+++ b/Assets/Scripts/Minion/MinionBehaviour.cs
@@ -151,6 +151,7 @@ public class MinionBehaviour : Entity
         {
             hpBar.enabled = false;
             minionCollider.enabled = false;
+            agent.SetDestination(transform.position);
             Die();
             target = transform;
         }

--- a/Assets/Scripts/Minion/State/AttackState.cs
+++ b/Assets/Scripts/Minion/State/AttackState.cs
@@ -5,12 +5,11 @@ using UnityEngine;
 public class AttackState : StateMachineBehaviour
 {
     private MinionBehaviour minionBehaviour;
-    private Entity target;
-    private float transitionDelay = 0.25f;
 
     public override void OnStateEnter(Animator animator, AnimatorStateInfo stateInfo, int layerIndex)
     {
         minionBehaviour = animator.GetComponent<MinionBehaviour>();
+        minionBehaviour.isAttack = true;
     }
 
     public override void OnStateUpdate(Animator animator, AnimatorStateInfo stateInfo, int layerIndex)
@@ -20,8 +19,6 @@ public class AttackState : StateMachineBehaviour
             if(minionBehaviour.target.GetComponent<Entity>().hp <= 0  )
             {
                 animator.SetBool(MinionBehaviour.hashAttack, false);
-                
-
             }
         }
     }


### PR DESCRIPTION
## 요약
- 미니언 죽음,공격중에 이동하던 버그 수정

## 작업 내용
- 죽음, 공격시 agent.SetDestination(transform.position);를 통해 이동하지 않도록 수정

## 참고 사항
