### PR TITLE
TBD-129 맵 위치 재설정 기능 추가

### DIFF
--- a/Assets/Resources/Prefabs/MAP/MapPreview.prefab
+++ b/Assets/Resources/Prefabs/MAP/MapPreview.prefab
@@ -75,10 +75,10 @@ LineRenderer:
   m_SortingLayer: 0
   m_SortingOrder: 0
   m_Positions:
-  - {x: -75, y: -1.110223e-16, z: -10}
-  - {x: 75, y: -1.110223e-16, z: -10}
-  - {x: 75, y: 1.110223e-16, z: 10}
-  - {x: -75, y: 1.110223e-16, z: 10}
+  - {x: -20, y: -0.05, z: -30}
+  - {x: 20, y: -0.05, z: -30}
+  - {x: 20, y: -0.05, z: 30}
+  - {x: -20, y: 0.05, z: 30}
   m_Parameters:
     serializedVersion: 3
     widthMultiplier: 0.2
@@ -492,7 +492,7 @@ Transform:
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 1, z: 0, w: 0}
   m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 150, y: 0.1, z: 20}
+  m_LocalScale: {x: 40, y: 0.1, z: 60}
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 285729870990110068}

--- a/Assets/Resources/Prefabs/UI/Popup/UI_BattlePopup.prefab
+++ b/Assets/Resources/Prefabs/UI/Popup/UI_BattlePopup.prefab
@@ -301,6 +301,141 @@ MonoBehaviour:
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
   m_PixelsPerUnitMultiplier: 1
+--- !u!1 &2870264709396904879
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3982545076267419315}
+  - component: {fileID: 8280407527195315063}
+  - component: {fileID: 6096331914623406765}
+  m_Layer: 5
+  m_Name: PauseText
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &3982545076267419315
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2870264709396904879}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 8743884820884944746}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &8280407527195315063
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2870264709396904879}
+  m_CullTransparentMesh: 1
+--- !u!114 &6096331914623406765
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2870264709396904879}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: Pause
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 6add902063809fe43a8f6580193cca5d, type: 2}
+  m_sharedMaterial: {fileID: 1569234521761865867, guid: 6add902063809fe43a8f6580193cca5d,
+    type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4281479730
+  m_fontColor: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 36
+  m_fontSizeBase: 36
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 2
+  m_VerticalAlignment: 512
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_enableWordWrapping: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 1
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
 --- !u!1 &2989941920487573296
 GameObject:
   m_ObjectHideFlags: 0
@@ -337,6 +472,7 @@ RectTransform:
   - {fileID: 6899036993686789842}
   - {fileID: 3012983348950809464}
   - {fileID: 8960836061929917612}
+  - {fileID: 8743884820884944746}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
@@ -533,6 +669,127 @@ RectTransform:
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 100, y: 100}
   m_Pivot: {x: 0.5, y: 0.5}
+--- !u!1 &3449266208238461217
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8743884820884944746}
+  - component: {fileID: 4345910953864593085}
+  - component: {fileID: 1968426331741526262}
+  - component: {fileID: 1099124132439633616}
+  m_Layer: 5
+  m_Name: PauseButton
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &8743884820884944746
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3449266208238461217}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 3982545076267419315}
+  m_Father: {fileID: 5922110116700739430}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 60, y: -60}
+  m_SizeDelta: {x: 160, y: 160}
+  m_Pivot: {x: 0, y: 1}
+--- !u!222 &4345910953864593085
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3449266208238461217}
+  m_CullTransparentMesh: 1
+--- !u!114 &1968426331741526262
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3449266208238461217}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10905, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!114 &1099124132439633616
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3449266208238461217}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 1968426331741526262}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls: []
 --- !u!1 &3488016731854257594
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/Manager/GameManagerEx.cs
+++ b/Assets/Scripts/Manager/GameManagerEx.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using UnityEngine;
+using UnityEngine.AI;
 using UnityEngine.XR.Interaction.Toolkit.Interactors;
 using UnityEngine.XR.Interaction.Toolkit.Samples.ARStarterAssets;
 using UnityEngine.XR.Interaction.Toolkit.Samples.StarterAssets;
@@ -8,6 +9,9 @@ public class GameManagerEx
 {
     private ObjectSpawner _objectSpawner;
     private GameObject _map;
+
+    private Mana _mana;
+    public Mana Mana => _mana;
 
     public void Init()
     {
@@ -41,9 +45,36 @@ public class GameManagerEx
 
         Transform mapPreview = _objectSpawner.transform.GetChild(0);
 
-        _map = Managers.Resource.Instantiate("MAP/FinalMap");
-        _map.transform.SetPositionAndRotation(mapPreview.position, mapPreview.rotation);
-        _map.transform.localScale = mapPreview.localScale;
+        if (_map)
+        {
+            NavMeshAgent[] minions = _map.GetComponentsInChildren<NavMeshAgent>();
+
+            foreach (NavMeshAgent minion in minions)
+            {
+                minion.enabled = false;
+            }
+
+            _map.transform.SetPositionAndRotation(mapPreview.position, mapPreview.rotation);
+            _map.transform.localScale = mapPreview.localScale;
+            _map.transform.Rotate(Vector3.up, -45f);
+
+            foreach (NavMeshAgent minion in minions)
+            {
+                minion.enabled = true;
+            }
+
+            _map.SetActive(true);
+        }
+        else
+        {
+            _map = Managers.Resource.Instantiate("MAP/FinalMap");
+
+            _map.transform.SetPositionAndRotation(mapPreview.position, mapPreview.rotation);
+            _map.transform.localScale = mapPreview.localScale;
+            _map.transform.Rotate(Vector3.up, -45f);
+        }
+
+        Managers.Resource.Load<Material>("Materials/M_Plane").color = Color.clear;
 
         Object.Destroy(mapPreview.gameObject);
         _objectSpawner.gameObject.SetActive(false);
@@ -55,6 +86,18 @@ public class GameManagerEx
     {
         if (!_map) return false;
         Object.Destroy(_map);
+        return true;
+    }
+
+    public bool PauseGame()
+    {
+        if (!_map || !_objectSpawner) return false;
+
+        _map.SetActive(false);
+        _objectSpawner.gameObject.SetActive(true);
+
+        Managers.Resource.Load<Material>("Materials/M_Plane").color = new Color(1f, 1f, 0f, 0.05f);
+
         return true;
     }
 }

--- a/Assets/Scripts/Manager/MinionSpawnManager.cs
+++ b/Assets/Scripts/Manager/MinionSpawnManager.cs
@@ -48,7 +48,7 @@ public class MinionSpawnManager : MonoBehaviour
 
     private MinionBehaviour CreateMinion()
     {
-        MinionBehaviour minionInstance = Instantiate(minionPrefab, transform.parent);
+        MinionBehaviour minionInstance = Instantiate(minionPrefab, spawnPoint, false);
         minionInstance.ObjectPool = objectPool;
         minionInstance.name = count.ToString();
         count++;
@@ -72,7 +72,7 @@ public class MinionSpawnManager : MonoBehaviour
         Destroy(minion.gameObject);
     }
 
-    private void Start()
+    private void OnEnable()
     {
         waveSpawnRoutine = StartCoroutine(WaveSpawnRoutine(waveCreateDelay, startDelay));
     }

--- a/Assets/Scripts/Skill/Mana.cs
+++ b/Assets/Scripts/Skill/Mana.cs
@@ -7,7 +7,7 @@ public class Mana : MonoBehaviour
     private const int MaxMana = 10;
     private const int MinMana = 0;
     public int CurrentMana { get; private set; } = MaxMana;
-    public float regenRate = 2f;
+    private const float regenRate = 0.5f;
     private float _elapsedTime;
 
     public event Action ManaChanged;
@@ -18,7 +18,7 @@ public class Mana : MonoBehaviour
 
         foreach (Skill skill in skills)
         {
-            skill.mana = this;
+            skill.Mana = this;
             ManaChanged += skill.ChangeColor;
         }
 

--- a/Assets/Scripts/Skill/Skill.cs
+++ b/Assets/Scripts/Skill/Skill.cs
@@ -7,15 +7,7 @@ using UnityEngine.UI;
 [RequireComponent(typeof(Image))]
 public class Skill : MonoBehaviour, IBeginDragHandler, IDragHandler, IEndDragHandler
 {
-    private Mana _mana;
-    public Mana mana
-    {
-        get => _mana;
-        set
-        {
-            if (!_mana) _mana = value;
-        }
-    }
+    public Mana Mana { get; set; }
 
     [Header("UI")]
     public Sprite iconSprite;
@@ -26,7 +18,7 @@ public class Skill : MonoBehaviour, IBeginDragHandler, IDragHandler, IEndDragHan
 
     [Header("오브젝트")]
     public Vector3 offset = Vector3.up * 9f;
-    public LayerMask groundLayer = 1 << 8; // Ground 레이어
+    public LayerMask groundLayer = 1 << 8 | 1 << 9; // Ground 레이어
     public GameObject effectToSpawn;
     protected GameObject draggingObject;
     protected SRPCircleRegionProjector Circle;
@@ -60,18 +52,19 @@ public class Skill : MonoBehaviour, IBeginDragHandler, IDragHandler, IEndDragHan
 
     private void OnDestroy()
     {
-        _mana.ManaChanged -= ChangeColor;
+        Mana.ManaChanged -= ChangeColor;
+        Destroy(draggingObject);
     }
 
     /// <summary>
     /// 아이콘을 현재 마나에 따라 흑백으로 전환
     /// </summary>
     public void ChangeColor() =>
-        _iconImage.material.SetFloat("_Grayscale", Convert.ToSingle(_mana.CurrentMana < requireMana));
+        _iconImage.material.SetFloat("_Grayscale", Convert.ToSingle(Mana.CurrentMana < requireMana));
 
     public void OnBeginDrag(PointerEventData eventData)
     {
-        if (_mana.CurrentMana < requireMana) return;
+        if (Mana.CurrentMana < requireMana) return;
 
         _baseImage.color = activeColor;
 
@@ -107,7 +100,7 @@ public class Skill : MonoBehaviour, IBeginDragHandler, IDragHandler, IEndDragHan
         if (_isAble)
         {
             Activate();
-            _mana.UpdateMana(-requireMana);
+            Mana.UpdateMana(-requireMana);
         }
         else
         {

--- a/Assets/Scripts/UI/Popup/UI_BattlePopup.cs
+++ b/Assets/Scripts/UI/Popup/UI_BattlePopup.cs
@@ -19,6 +19,11 @@ public class UI_BattlePopup : UI_Popup
         Steminas,
     }
 
+    enum Buttons
+    {
+        PauseButton,
+    }
+
     float sec;
     int min;
 
@@ -29,6 +34,8 @@ public class UI_BattlePopup : UI_Popup
 
         BindText(typeof(Texts));
         BindImage(typeof(Images));
+        BindButton(typeof(Buttons));
+
         min = 0;
         sec = 0;
 
@@ -39,6 +46,8 @@ public class UI_BattlePopup : UI_Popup
         GetImage((int)Images.Skill3Image).gameObject.GetOrAddComponent<Skill>();
         GetImage((int)Images.Skill4Image).gameObject.GetOrAddComponent<Skill>();
         GetImage((int)Images.Steminas).gameObject.GetOrAddComponent<Mana>().FindListener();
+
+        GetButton((int)Buttons.PauseButton).gameObject.BindEvent(OnClickPauseButton);
 
         return true;
     }
@@ -56,4 +65,10 @@ public class UI_BattlePopup : UI_Popup
 
     }
 
+    private void OnClickPauseButton()
+    {
+        Managers.UI.ClosePopupUI(this);
+        Managers.UI.ShowPopupUI<UI_MapSettingPopup>();
+        Managers.Game.PauseGame();
+    }
 }


### PR DESCRIPTION
## 요약

![DefenseARGame - Prototype - Android - Unity 2022 3 19f1 _DX11_ 2024-07-30 17-04-14](https://github.com/user-attachments/assets/71b0a563-6c76-4b51-9aae-415c2f9bd850)

**맵 재배치**기능을 추가했습니다.

## 작업 내용

- **FinalMap 프리팹 변경**
  - Road에 있던 **Plane 오브젝트를 Cube로** 변경했습니다.
  - Structure를 포함한 자식 오브젝트의 레이어를 Default로 변경했습니다.
  - MapPreview 프리팹을 FinalMap의 사이즈에 맞게 변경했습니다.
- 미니언이 생성될 때 **부모 오브젝트를 spawnPoint로** 변경했습니다.
- `UI_BattlePopup`에 Pause 버튼을 추가했습니다. 이 버튼을 터치했을 때 **맵을 재배치**할 수 있습니다.
- 마나의 회복 주기를 0.5초로 변경했습니다.

## 참고 사항

이번 작업을 진행하며 여러 문제점이 발생했습니다. **체크 표시된 목록은 이번 PR에서 해결되었습니다.**

- [ ] 맵 재배치 시, UI가 재생성되어 **마나, 플레이 타임이 초기화**되는 문제
- [x] 맵 재배치 후, 미니언이 맵에서 벗어나는 문제
- [X] Ray가 땅을 감지하지 못하는 문제