### PR TITLE
TBD-131 맵 재설정 후 마나, 플레이 타임이 초기화되는 버그 수정

### DIFF
--- a/Assets/Scripts/Data.meta
+++ b/Assets/Scripts/Data.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 07a1a028315c0af4db4d6f20a94fc46e
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Data/PlayData.cs
+++ b/Assets/Scripts/Data/PlayData.cs
@@ -1,0 +1,13 @@
+public readonly struct PlayData
+{
+    public readonly int currentMana;
+    public readonly int minute;
+    public readonly float second;
+
+    public PlayData(int mana, int min, float sec)
+    {
+        currentMana = mana;
+        minute = min;
+        second = sec;
+    }
+}

--- a/Assets/Scripts/Data/PlayData.cs.meta
+++ b/Assets/Scripts/Data/PlayData.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5a2cd5c9cf173d440a9ff1a6b108dd30
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Manager/GameManagerEx.cs
+++ b/Assets/Scripts/Manager/GameManagerEx.cs
@@ -10,8 +10,7 @@ public class GameManagerEx
     private ObjectSpawner _objectSpawner;
     private GameObject _map;
 
-    private Mana _mana;
-    public Mana Mana => _mana;
+    public PlayData PlayData { get; set; }
 
     public void Init()
     {
@@ -72,6 +71,8 @@ public class GameManagerEx
             _map.transform.SetPositionAndRotation(mapPreview.position, mapPreview.rotation);
             _map.transform.localScale = mapPreview.localScale;
             _map.transform.Rotate(Vector3.up, -45f);
+
+            PlayData = new PlayData(10, 0, 0);
         }
 
         Managers.Resource.Load<Material>("Materials/M_Plane").color = Color.clear;

--- a/Assets/Scripts/UI/Popup/UI_BattlePopup.cs
+++ b/Assets/Scripts/UI/Popup/UI_BattlePopup.cs
@@ -26,6 +26,7 @@ public class UI_BattlePopup : UI_Popup
 
     float sec;
     int min;
+    Mana _mana;
 
     public override bool Init()
     {
@@ -36,8 +37,8 @@ public class UI_BattlePopup : UI_Popup
         BindImage(typeof(Images));
         BindButton(typeof(Buttons));
 
-        min = 0;
-        sec = 0;
+        min = Managers.Game.PlayData.minute;
+        sec = Managers.Game.PlayData.second;
 
         GetText((int)Texts.PlayTimeText).text = "00:00";
 
@@ -45,7 +46,10 @@ public class UI_BattlePopup : UI_Popup
         GetImage((int)Images.Skill2Image).gameObject.GetOrAddComponent<MonsoonSkill>();
         GetImage((int)Images.Skill3Image).gameObject.GetOrAddComponent<Skill>();
         GetImage((int)Images.Skill4Image).gameObject.GetOrAddComponent<HealSkill>();
-        GetImage((int)Images.Steminas).gameObject.GetOrAddComponent<Mana>().FindListener();
+
+        _mana = GetImage((int)Images.Steminas).gameObject.GetOrAddComponent<Mana>();
+        _mana.FindListener();
+        _mana.UpdateMana(-10 + Managers.Game.PlayData.currentMana);
 
         GetButton((int)Buttons.PauseButton).gameObject.BindEvent(OnClickPauseButton);
         
@@ -72,6 +76,8 @@ public class UI_BattlePopup : UI_Popup
     {
         Managers.UI.ClosePopupUI(this);
         Managers.UI.ShowPopupUI<UI_MapSettingPopup>();
+
         Managers.Game.PauseGame();
+        Managers.Game.PlayData = new PlayData(_mana.CurrentMana, min, sec);
     }
 }


### PR DESCRIPTION
## 요약

![Animation](https://github.com/user-attachments/assets/b7fd1769-b613-4e19-a407-da2d6c1723b1)

맵을 재배치했을 때, 마나, 플레이 타임이 초기화되는 문제가 있었습니다.

이를 수정했습니다.

## 작업 내용

`PlayData` 구조체를 생성하여 게임이 Pause 될 때 마나와 플레이 타임 값을 임시로 저장합니다.

만약 새로운 게임일 경우, 마나값 10, 분 0, 초 0 으로 새로운 데이터를 생성합니다.

## 참고 사항

구조체에 생성자를 사용한 이유는 `new()`로 편하게 생성하고 싶었기 때문입니다.