### PR TITLE
TBD-136-Skill-Ice-Modifying

### DIFF
--- a/Assets/Scripts/Skill/HealSkill.cs
+++ b/Assets/Scripts/Skill/HealSkill.cs
@@ -13,7 +13,7 @@ public class HealSkill : Skill
         SkillName_KR = "회복";
         Description = "";
         RequireMana = 7;
-        Damage = 30;
+        Damage = -30;   // tooltip 개발 : 30 -> -30 수정
         Radius = 9f;
         base.Init();
     }
@@ -39,7 +39,7 @@ public class HealSkill : Skill
         for (int j = 0; j < targetAmount; j++)
         {
             if (!targets[j].CompareTag("Minion")) continue;
-            targets[j].GetComponent<Minion>().GetHit(-Damage);
+            targets[j].GetComponent<Minion>().GetHit(Damage);   // tooltip 개발 : -Damage -> Damage 수정
         }
     }
 }

--- a/Assets/Scripts/Skill/HealSkill.cs
+++ b/Assets/Scripts/Skill/HealSkill.cs
@@ -13,7 +13,7 @@ public class HealSkill : Skill
         SkillName_KR = "회복";
         Description = "";
         RequireMana = 7;
-        Damage = -30;   // tooltip 개발 : 30 -> -30 수정
+        Damage = -10;
         Radius = 9f;
         base.Init();
     }
@@ -39,7 +39,7 @@ public class HealSkill : Skill
         for (int j = 0; j < targetAmount; j++)
         {
             if (!targets[j].CompareTag("Minion")) continue;
-            targets[j].GetComponent<Minion>().GetHit(Damage);   // tooltip 개발 : -Damage -> Damage 수정
+            targets[j].GetComponent<Minion>().GetHit(Damage);
         }
     }
 }

--- a/Assets/Scripts/Skill/IceSkill.cs
+++ b/Assets/Scripts/Skill/IceSkill.cs
@@ -1,6 +1,7 @@
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
+using UnityEngine.AI;
 using UnityEngine.UIElements;
 
 public class IceSkill : Skill
@@ -15,7 +16,7 @@ public class IceSkill : Skill
         SkillName_KR = "아이스 익스플로젼";
         Description = "";
         RequireMana = 4;
-        Damage = 50;
+        Damage = 1;
         Radius = 15f;
         base.Init();
     }
@@ -35,11 +36,11 @@ public class IceSkill : Skill
     {
         for( int i = 0; i < 5; ++i )
         {
-            TakeDamage(position, (Damage/2) / 5);
+            TakeDamage(position, Damage);
             yield return new WaitForSeconds(time);
         }
-        TakeDamage(position, Damage / 2);
-
+        TakeDamage(position, Damage * 5);
+        TakeSlow(position);
     }
 
     private void TakeDamage(Vector3 position, int damage)
@@ -50,6 +51,24 @@ public class IceSkill : Skill
         {
             if (!targets[j].CompareTag("Minion")) continue;
             targets[j].GetComponent<Minion>().GetHit(damage);
+        }
+    }
+
+    IEnumerator SpeedSlowCo(Collider targetColl)
+    {
+        targetColl.gameObject.GetComponent<NavMeshAgent>().speed = 0.6f;
+        yield return new WaitForSeconds(1f);
+        targetColl.gameObject.GetComponent<NavMeshAgent>().speed = 2f;        
+    }
+
+    private void TakeSlow(Vector3 position)
+    {
+        int targetAmount = Physics.OverlapSphereNonAlloc(position, Radius / 2, targets, 1 << 6);
+
+        for (int j = 0; j < targetAmount; j++)
+        {
+            if (!targets[j].CompareTag("Minion")) continue;
+            StartCoroutine(SpeedSlowCo(targets[j]));
         }
     }
 

--- a/Assets/Scripts/Skill/MeteorSkill.cs
+++ b/Assets/Scripts/Skill/MeteorSkill.cs
@@ -13,7 +13,7 @@ public class MeteorSkill : Skill
         SkillName_KR = "메테오";
         Description = "";
         RequireMana = 4;
-        Damage = 50;
+        Damage = 15;
         Radius = 9f;
         base.Init();
     }

--- a/Assets/Scripts/Skill/MonsoonSkill.cs
+++ b/Assets/Scripts/Skill/MonsoonSkill.cs
@@ -12,7 +12,7 @@ public class MonsoonSkill : Skill
         Description = "";
         RequireMana = 3;
         Damage = 0;
-        Radius = 3f;
+        Radius = 9f;
         base.Init();
     }
 

--- a/Assets/Scripts/UI/Popup/UI_BattlePopup.cs
+++ b/Assets/Scripts/UI/Popup/UI_BattlePopup.cs
@@ -108,7 +108,18 @@ public class UI_BattlePopup : UI_Popup
         {
             int index = i; // 클로저 문제 해결을 위해 지역 변수 사용
             skill = GetImage(i).gameObject.GetOrAddComponent<Skill>();
-            GetText(i).text = $"스킬 이름 : {skill.SkillName_KR}\n스킬 설명 : {skill.Description}\n필요 마나 : {skill.RequireMana}\n피해량 : {skill.Damage}\n스킬 범위 : {skill.Radius}";
+            if (skill.Damage > 0)
+            {
+                GetText(i).text = $"스킬 이름 : {skill.SkillName_KR}\n스킬 설명 : {skill.Description}\n필요 마나 : {skill.RequireMana}\n피해량 : {skill.Damage}\n스킬 범위 : {skill.Radius}";
+            }
+            else if(skill.Damage < 0)
+            {
+                GetText(i).text = $"스킬 이름 : {skill.SkillName_KR}\n스킬 설명 : {skill.Description}\n필요 마나 : {skill.RequireMana}\n회복량 : {-skill.Damage}\n스킬 범위 : {skill.Radius}";
+            }
+            else
+            {
+                GetText(i).text = $"스킬 이름 : {skill.SkillName_KR}\n스킬 설명 : {skill.Description}\n필요 마나 : {skill.RequireMana}\n스킬 범위 : {skill.Radius}";
+            }
             GetImage(i).gameObject.BindEvent(() => OnPointerDownImage(index), Define.UIEvent.PointerDown);
             GetImage(i).gameObject.BindEvent(() => OnPointerUpImage(index), Define.UIEvent.PointerUp);
             GetObject(i).SetActive(false);


### PR DESCRIPTION
## 요약
아이스 익스플로젼 스킬 매커니즘을 변경하였습니다.
도트데미지 후 폭발 시 미니언의 속도를 1초동안 느리게 합니다.

## 구현 내용
![iceSkill](https://github.com/user-attachments/assets/e9f63f6b-30a4-426e-b1d2-979fd2d5c58e)
TakeSlow() 메소드를 추가하여 폭발 시전 시각에 범위 내에 있는 미니언의 속력을 조정하도록 하였습니다.
코루틴 SpeedSlowCo이 미니언의 속력을 0.6으로 설정하고 1초 후 다시 2로 돌아오게 합니다.

## 참고 사항
스킬들의 데미지가 미니언의 체력에 비해 상대적으로 너무 높아 밸런스가 맞지 않는 문제를 테스팅 중 확인하였습니다.
이에 따라 스킬들의 데미지를 각각 약 1/5로 축소하였습니다.