### PR TITLE
TBD-142 맵을 배치할 때 AR Session 리셋

### DIFF
--- a/Assets/Hovl Studio.meta
+++ b/Assets/Hovl Studio.meta
@@ -1,8 +1,0 @@
-fileFormatVersion: 2
-guid: 0b31d124a34f94241b3b5fbaa8745367
-folderAsset: yes
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/Assets/Scripts/Manager/GameManagerEx.cs
+++ b/Assets/Scripts/Manager/GameManagerEx.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.AI;
+using UnityEngine.XR.ARFoundation;
 using UnityEngine.XR.Interaction.Toolkit.Interactors;
 using UnityEngine.XR.Interaction.Toolkit.Samples.ARStarterAssets;
 using UnityEngine.XR.Interaction.Toolkit.Samples.StarterAssets;
@@ -11,10 +12,12 @@ public class GameManagerEx
     private GameObject _map;
 
     public PlayData PlayData { get; set; }
+    public ARSession AR { get; private set; }
 
     public void Init()
     {
         _objectSpawner = Utils.GetOrAddComponent<ObjectSpawner>(Managers.Resource.Instantiate("MAP/Object Spawner"));
+        AR = Object.FindObjectOfType<ARSession>();
 
         if (_objectSpawner)
         {
@@ -24,12 +27,16 @@ public class GameManagerEx
             };
 
             _objectSpawner.GetComponent<ARInteractorSpawnTrigger>().arInteractor = Object.FindObjectOfType<XRRayInteractor>();
+            AR.enabled = false;
         }
     }
 
     public bool ReadyGame()
     {
         if (!_objectSpawner) return false;
+
+        AR.enabled = true;
+        AR.Reset();
 
         _objectSpawner.gameObject.SetActive(true);
 
@@ -86,6 +93,8 @@ public class GameManagerEx
     public bool FinishGame()
     {
         if (!_map) return false;
+        AR.Reset();
+        AR.enabled = false;
         Object.Destroy(_map);
         return true;
     }
@@ -93,6 +102,8 @@ public class GameManagerEx
     public bool PauseGame()
     {
         if (!_map || !_objectSpawner) return false;
+
+        AR.Reset();
 
         _map.SetActive(false);
         _objectSpawner.gameObject.SetActive(true);


### PR DESCRIPTION
## 요약

AR Session의 `Reset()`을 호출하여 어긋난 평면을 지우고 다시 인식합니다.

## 작업 내용

1. 타이틀에서 AR Session을 비활성화하여 맵 배치 단계에서 맵 프리뷰가 미리 배치되는 문제를 방지했습니다.
2. 맵을 재배치할 때, 이미 인식된 평면을 제거하고, 다시 인식합니다.
3. Level 팝업으로 이동할 때, AR Session을 비활성화합니다. 이유는 1번과 같습니다.

## 참고 사항

맵 재배치 때, 맵 프리뷰가 미리 배치되지 않는지 확인이 필요합니다.

- [AR Session : Simple AR (영문)](https://github.com/Unity-Technologies/arfoundation-samples#simple-ar)